### PR TITLE
Fix CSRF protection for payment callback

### DIFF
--- a/boilerplate/config/routes.php
+++ b/boilerplate/config/routes.php
@@ -91,9 +91,11 @@ Router::scope('/', function (RouteBuilder $routes) {
     $routes->connect('/payments/build-request/:id', ['controller' => 'Payments', 'action' => 'buildRequest'])
         ->setPass(['id']);
 
-    $routes->connect('/payments/callback', ['controller' => 'Payments', 'action' => 'callback']);
-
     $routes->fallbacks(DashedRoute::class);
+});
+
+Router::scope('/', function (RouteBuilder $routes) {
+    $routes->connect('/payments/callback', ['controller' => 'ClientPayments', 'action' => 'callback']);
 });
 
 /*

--- a/boilerplate/src/Controller/ClientPaymentsController.php
+++ b/boilerplate/src/Controller/ClientPaymentsController.php
@@ -90,7 +90,7 @@ class ClientPaymentsController extends AppController
                 'currency' => 'EUR',
                 'accepturl' => 'http://localhost:8765/client-payments/success',
                 'cancelurl' => 'http://localhost:8765/client-payments/topup',
-                'callbackurl' => 'http://localhost:8765/client-payments/callback',
+                'callbackurl' => 'http://localhost:8765/payments/callback',
                 'test' => 1,
                 'p_firstname' => 'Test',
                 'p_lastname' => 'User',
@@ -117,6 +117,8 @@ class ClientPaymentsController extends AppController
      */
     public function callback()
     {
+        $this->request->allowMethod(['post']);
+
         try {
             // Handle both GET and POST data as Paysera callbacks can come via either method
             $data = array_merge($this->request->getQuery(), $this->request->getData());


### PR DESCRIPTION
**Problem:**

1. CakePHP applies CSRF protection globally.
2. Payment gateway callback is external POST request that can't include CSRF token.
3. This caused valid payment to be rejected.

**Changes:**

1. Created a separate route scope for /payments/callback without CSRF
2. Restricted callback to POST only requests

**Testing:**

1. Test Payment Flow
- Go to the dashboard page.
- Click to topup you wallet.
- Enter amount for example: 10 euro.
- Pay with paysera.

2. Success case: no CSRF errors in logs/error.log, balance updates correctly, payment appears in transaction history. Try sending GET request to /payments/callback - should reject.
3. Failure case: balance not updated, errors in logs, payment not appeared in transation history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the payment callback URL to use `/payments/callback`.
  * Ensured the payment callback endpoint only accepts POST requests for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->